### PR TITLE
Incorrect buffer values

### DIFF
--- a/app/src/main/java/com/mcuhq/simplebluetooth/MainActivity.java
+++ b/app/src/main/java/com/mcuhq/simplebluetooth/MainActivity.java
@@ -327,6 +327,7 @@ public class MainActivity extends AppCompatActivity {
                     // Read from the InputStream
                     bytes = mmInStream.available();
                     if(bytes != 0) {
+                        buffer = new byte[1024];
                         SystemClock.sleep(100); //pause and wait for rest of data. Adjust this depending on your sending speed.
                         bytes = mmInStream.available(); // how many bytes are ready to be read?
                         bytes = mmInStream.read(buffer, 0, bytes); // record how many bytes we actually read


### PR DESCRIPTION
There is an issue with reading from buffer, when sending more than one message the value in the buffer becomes incorrect.
Example:
Message 1: Hello
It will be displayed correctly, but when we send another message (Shorter than the previous message)
Message 2: Bye

The message will be displayed as "Byelo"

Re-initating the buffer fixes this issue